### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/NodeServer/index.js
+++ b/NodeServer/index.js
@@ -2,17 +2,36 @@ var app = require('http').createServer(handler)
 var io = require('socket.io')(app);
 var fs = require('fs');
 
-function handler(req, res) {
-    fs.readFile(__dirname + req.url,
-        function (err, data) {
-            if (err) {
-                res.writeHead(500);
-                return res.end('Error loading index.html');
-            }
+const path = require('path');
 
-            res.writeHead(200);
-            res.end(data);
-        });
+function handler(req, res) {
+    const ROOT = __dirname; // Define the safe root directory
+    let filePath;
+
+    try {
+        // Resolve and normalize the file path
+        filePath = path.resolve(ROOT, '.' + req.url);
+        filePath = fs.realpathSync(filePath);
+
+        // Ensure the file path is within the root directory
+        if (!filePath.startsWith(ROOT)) {
+            res.writeHead(403);
+            return res.end('Access denied');
+        }
+    } catch (err) {
+        res.writeHead(400);
+        return res.end('Invalid file path');
+    }
+
+    fs.readFile(filePath, function (err, data) {
+        if (err) {
+            res.writeHead(500);
+            return res.end('Error loading file');
+        }
+
+        res.writeHead(200);
+        res.end(data);
+    });
 }
 
 io.of('/kizuna').on('connection', (socket) => {


### PR DESCRIPTION
Potential fix for [https://github.com/1996scarlet/OpenVtuber/security/code-scanning/1](https://github.com/1996scarlet/OpenVtuber/security/code-scanning/1)

To fix the issue, we need to validate and sanitize the user-provided `req.url` before using it to construct a file path. The best approach is to resolve the file path relative to a safe root directory and ensure it does not escape this directory. This can be achieved using `path.resolve` and `fs.realpathSync` to normalize the path and remove any malicious components like `../`. Additionally, we should check that the resolved path starts with the intended root directory.

Steps to fix:
1. Define a safe root directory (e.g., `__dirname`).
2. Use `path.resolve` to construct the full path and normalize it.
3. Use `fs.realpathSync` to resolve symbolic links.
4. Verify that the resolved path starts with the root directory.
5. If the path is invalid or outside the root directory, return a 403 error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
